### PR TITLE
Adding transformers-compat >=0.3 to dependencies

### DIFF
--- a/Glob.cabal
+++ b/Glob.cabal
@@ -31,6 +31,7 @@ Library
                 , dlist        >= 0.4 && < 0.8
                 , filepath     >= 1.1 && < 1.5
                 , transformers >= 0.2 && < 0.6
+                , transformers-compat >= 0.3 && < 0.6
 
    if impl(ghc < 8.0)
       Build-Depends: semigroups >= 0.18 && < 0.19


### PR DESCRIPTION
 The package depends on `transformers >=0.2` and the `System.FilePath.Glob.Base` module now uses `Control.Monad.Trans.Except`. But older version of `transformers` lacks the `Control.Monad.Trans.Except` module.

So it is necessary either bumping the lower bound of `transformers` to `>=0.4` or adding `transformers-compat` to dependencies. This PR choose the latter way.
