### PR TITLE
Bump dlist upper bound to 0.9

### DIFF
--- a/Glob.cabal
+++ b/Glob.cabal
@@ -28,7 +28,7 @@ Library
    Build-Depends: base         >= 4 && < 5
                 , containers   <  0.6
                 , directory    <  1.3
-                , dlist        >= 0.4 && < 0.8
+                , dlist        >= 0.4 && < 0.9
                 , filepath     >= 1.1 && < 1.5
                 , transformers >= 0.2 && < 0.6
                 , transformers-compat >= 0.3 && < 0.6
@@ -56,7 +56,7 @@ Test-Suite glob-tests
    Build-Depends: base                       >= 4 && < 5
                 , containers                 <  0.6
                 , directory                  <  1.3
-                , dlist                      >= 0.4 && < 0.8
+                , dlist                      >= 0.4 && < 0.9
                 , filepath                   >= 1.1 && < 1.5
                 , transformers               >= 0.2 && < 0.6
                 , transformers-compat        >= 0.3 && < 0.6


### PR DESCRIPTION
I just released [`dlist-0.8`](https://github.com/spl/dlist/releases/tag/v0.8). I didn't test this change to `Glob`, but I don't think it will be break anything.