### PR TITLE
Allow building with directory-1.3

### DIFF
--- a/Glob.cabal
+++ b/Glob.cabal
@@ -27,7 +27,7 @@ Source-Repository head
 Library
    Build-Depends: base         >= 4 && < 5
                 , containers   <  0.6
-                , directory    <  1.3
+                , directory    <  1.4
                 , dlist        >= 0.4 && < 0.9
                 , filepath     >= 1.1 && < 1.5
                 , transformers >= 0.2 && < 0.6
@@ -55,7 +55,7 @@ Test-Suite glob-tests
 
    Build-Depends: base                       >= 4 && < 5
                 , containers                 <  0.6
-                , directory                  <  1.3
+                , directory                  <  1.4
                 , dlist                      >= 0.4 && < 0.9
                 , filepath                   >= 1.1 && < 1.5
                 , transformers               >= 0.2 && < 0.6


### PR DESCRIPTION
GHC 8.0.2 will ship with `directory-1.3`. This PR allows `Glob` to build with `directory-1.3` (and thus with GHC 8.0.2).