### PR TITLE
Control whether unmatched files should be returned

### DIFF
--- a/Glob.cabal
+++ b/Glob.cabal
@@ -79,6 +79,7 @@ Test-Suite glob-tests
                   System.FilePath.Glob.Utils
                   Tests.Base
                   Tests.Compiler
+                  Tests.Directory
                   Tests.Instances
                   Tests.Matcher
                   Tests.Optimizer

--- a/System/FilePath/Glob.hs
+++ b/System/FilePath/Glob.hs
@@ -53,9 +53,11 @@ module System.FilePath.Glob
      -- *** Options
    , MatchOptions(..)
    , matchWith
+   , GlobOptions(..)
    , globDirWith
      -- **** Predefined option sets
    , matchDefault, matchPosix
+   , globDefault
      -- ** Miscellaneous
    , commonDirectory
    ) where
@@ -67,7 +69,8 @@ import System.FilePath.Glob.Base      ( Pattern
                                       , compile, compileWith, tryCompileWith
                                       , decompile
                                       )
-import System.FilePath.Glob.Directory ( globDir, globDirWith, globDir1, glob
+import System.FilePath.Glob.Directory ( GlobOptions(..), globDefault
+                                      , globDir, globDirWith, globDir1, glob
                                       , commonDirectory
                                       )
 import System.FilePath.Glob.Match     (match, matchWith)

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -6,6 +6,7 @@ import System.Environment (getArgs)
 import Test.Framework
 
 import qualified Tests.Compiler   as Compiler
+import qualified Tests.Directory  as Directory
 import qualified Tests.Instances  as Instances
 import qualified Tests.Matcher    as Matcher
 import qualified Tests.Optimizer  as Optimizer
@@ -29,4 +30,5 @@ tests =
    , Optimizer.tests
    , Simplifier.tests
    , Instances.tests
+   , Directory.tests
    ]

--- a/tests/Tests/Directory.hs
+++ b/tests/Tests/Directory.hs
@@ -1,0 +1,66 @@
+module Tests.Directory where
+
+import Test.Framework
+import Test.Framework.Providers.HUnit
+import Test.HUnit.Base
+import Control.Monad (filterM, zipWithM)
+import Data.Function (on)
+import Data.List ((\\), sort)
+import qualified Data.DList as DList
+import System.Directory (doesDirectoryExist)
+import System.FilePath (takeBaseName)
+
+import System.FilePath.Glob.Base
+import System.FilePath.Glob.Directory
+import System.FilePath.Glob.Utils
+
+tests = testGroup "Directory"
+   [ testCase "includeUnmatched" caseIncludeUnmatched
+   , testCase "onlyMatched" caseOnlyMatched
+   ]
+
+caseIncludeUnmatched = do
+   let pats = ["**/D*.hs", "**/[MU]*.hs"]
+   everything <- (DList.toList <$> getRecursiveContents "System")
+                 >>= removeDirectories
+   let expectedMatches =
+          [ [ "System/FilePath/Glob/Directory.hs" ]
+          , [ "System/FilePath/Glob/Match.hs"
+            , "System/FilePath/Glob/Utils.hs"
+            ]
+          ]
+   let everythingElse = everything \\ concat expectedMatches
+
+   result <- globDirWith (GlobOptions matchDefault True)
+                         (map compile pats)
+                         "System"
+   zipWithM assertEqualUnordered expectedMatches (fst result)
+
+   case snd result of
+       Nothing ->
+          assertFailure "Expected Just a list of unmatched files"
+       Just unmatched -> do
+          noDirs <- removeDirectories unmatched
+          assertEqualUnordered everythingElse noDirs
+
+caseOnlyMatched = do
+   let pats = ["**/D*.hs", "**/[MU]*.hs"]
+   let expectedMatches =
+          [ [ "System/FilePath/Glob/Directory.hs" ]
+          , [ "System/FilePath/Glob/Match.hs"
+            , "System/FilePath/Glob/Utils.hs"
+            ]
+          ]
+
+   result <- globDirWith globDefault
+                         (map compile pats)
+                         "System"
+
+   zipWithM assertEqualUnordered expectedMatches (fst result)
+   assertEqual "" Nothing (snd result)
+
+assertEqualUnordered :: (Ord a, Show a) => [a] -> [a] -> Assertion
+assertEqualUnordered = assertEqual "" `on` sort
+
+removeDirectories :: [FilePath] -> IO [FilePath]
+removeDirectories = filterM (fmap not . doesDirectoryExist)

--- a/tests/Tests/Directory.hs
+++ b/tests/Tests/Directory.hs
@@ -21,7 +21,7 @@ tests = testGroup "Directory"
 
 caseIncludeUnmatched = do
    let pats = ["**/D*.hs", "**/[MU]*.hs"]
-   everything <- (DList.toList <$> getRecursiveContents "System")
+   everything <- (fmap DList.toList (getRecursiveContents "System"))
                  >>= removeDirectories
    let expectedMatches =
           [ [ "System/FilePath/Glob/Directory.hs" ]


### PR DESCRIPTION
Fixes #11

* Add a `GlobOptions` data type which provides a new `Bool` flag to
  control whether unmatched files should be included in the results of
  the globbing functions.
* Change `globDir` to not return unmatched files so that it is more in
  line with `globDir1`.
* Change `globDirWith` to accept a `GlobOptions` rather than a
  `MatchOptions`.
* Change the result type of `globDirWith` so that the unmatched files
  are wrapped in `Maybe`, in order to easily distinguish the situations
  where there were no unmatched files vs where the user did not ask for
  a list of unmatched files to be collected.

These changes provide a significant performance boost in situations
where the user doesn't care about the unmatched files, e.g. for
functions like `glob`.

---

There are no tests covering these changes currently, but I could try to add some if you'd like?