### PR TITLE
Add isLiteral, fixes #10

### DIFF
--- a/System/FilePath/Glob.hs
+++ b/System/FilePath/Glob.hs
@@ -58,6 +58,7 @@ module System.FilePath.Glob
    , matchDefault, matchPosix
      -- ** Miscellaneous
    , commonDirectory
+   , isLiteral
    ) where
 
 import System.FilePath.Glob.Base      ( Pattern
@@ -66,6 +67,7 @@ import System.FilePath.Glob.Base      ( Pattern
                                       , matchDefault, matchPosix
                                       , compile, compileWith, tryCompileWith
                                       , decompile
+                                      , isLiteral
                                       )
 import System.FilePath.Glob.Directory ( globDir, globDirWith, globDir1, glob
                                       , commonDirectory

--- a/System/FilePath/Glob/Base.hs
+++ b/System/FilePath/Glob/Base.hs
@@ -17,6 +17,8 @@ module System.FilePath.Glob.Base
    , optimize
 
    , liftP, tokToLower
+
+   , isLiteral
    ) where
 
 import Control.Arrow                     (first)
@@ -638,3 +640,14 @@ sortCharRange = sortBy cmp
    cmp (Left   a)    (Right (b,_)) = compare a b
    cmp (Right (a,_)) (Left   b)    = compare a b
    cmp (Right (a,_)) (Right (b,_)) = compare a b
+
+-- |Returns `True` iff the given `Pattern` is a literal file path, i.e. it has
+-- no wildcards, character ranges, etc.
+isLiteral :: Pattern -> Bool
+isLiteral = all lit . unPattern
+ where
+   lit (Literal _) = True
+   lit ExtSeparator = True
+   lit PathSeparator = True
+   lit (LongLiteral _ _) = True
+   lit _ = False


### PR DESCRIPTION
It seemed to make the most sense to implement this function inside `System.FilePath.Glob.Base` and re-export it from `System.FilePath.Glob`, since implementing it elsewhere would have required a bit more fiddling with imports.