### PR TITLE
Fix `commonDirectory`, fixes #18

### DIFF
--- a/Glob.cabal
+++ b/Glob.cabal
@@ -75,6 +75,7 @@ Test-Suite glob-tests
    Other-Modules: System.FilePath.Glob.Base
                   System.FilePath.Glob.Directory
                   System.FilePath.Glob.Match
+                  System.FilePath.Glob.Primitive
                   System.FilePath.Glob.Simplify
                   System.FilePath.Glob.Utils
                   Tests.Base


### PR DESCRIPTION
I modified `unseparate` based on the following observations:

- the `Int` argument to the `Dir` and `AnyDir` constructors specifies the number of path separators directly following the `Pattern`
- however, the `AnyDirectory` token represents the string `**/` in a `Pattern`; therefore, we subtract 1 from the argument when unseparating. Otherwise, we end up with one too many separators.
- similarly, I changed the behaviour of `f` so that it produces `n` path separators rather than `n+1` as it was before.

The `unseparate` function is used in one other place, in `matchTypedAndGo` when we encounter an `AnyDir` pattern. The current test suite still passes, but I'm not really sure if that's enough to conclude that I haven't accidentally broken it; do you have any thoughts on that?