### PR TITLE
Use commonDirectory in globDir1

### DIFF
--- a/tests/Tests/Directory.hs
+++ b/tests/Tests/Directory.hs
@@ -26,6 +26,7 @@ tests = testGroup "Directory"
        [ testGroup "edge-cases" commonDirectoryEdgeCases
        , testProperty "property" prop_commonDirectory
        ]
+   , testCase "globDir1" caseGlobDir1
    ]
 
 caseIncludeUnmatched = do
@@ -70,6 +71,17 @@ caseOnlyMatched = do
 
    zipWithM assertEqualUnordered expectedMatches (fst result)
    assertEqual "" Nothing (snd result)
+
+caseGlobDir1 = do
+   -- this is little a bit of a hack; we pass the same pattern twice to ensure
+   -- that the optimization in the single pattern case is bypassed
+   let naiveGlobDir1 p = fmap head . globDir [p, p]
+   let pat = compile "FilePath/*/*.hs"
+   let dir = "System"
+
+   actual <- globDir1 pat dir
+   expected <- naiveGlobDir1 pat dir
+   assertEqual "" expected actual
 
 assertEqualUnordered :: (Ord a, Show a) => [a] -> [a] -> Assertion
 assertEqualUnordered = assertEqual "" `on` sort


### PR DESCRIPTION
resolves #15

I decided to leave `globDir` as-is for now, as even though a similar optimisation might be possible there, I think it's going to be nontrivial to find a common directory prefix of a set of patterns. Right now, this optimisation applies to just `globDir1` and `glob`, i.e. the globbing functions which take a single pattern.