### PR TITLE
Make warnings cause CI builds to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ env:
    - CABALVER=1.18 GHCVER=7.4.1 # Debian 7
    - CABALVER=1.20 GHCVER=7.6.3 # Debian 8
    - CABALVER=1.18 GHCVER=7.8.4
-   - CABALVER=1.22 GHCVER=7.10.1
+   - CABALVER=1.22 GHCVER=7.10.3
    - CABALVER=1.24 GHCVER=8.0.2
    - CABALVER=1.24 GHCVER=8.2.1
    - CABALVER=head GHCVER=head
@@ -26,7 +26,7 @@ install:
 
 script:
    - cabal configure --enable-tests --enable-benchmarks -v2
-   - cabal build
+   - cabal build --ghc-options=-Werror
    - cabal test --show-details=failures
    - cabal haddock
    - cabal check

--- a/Glob.cabal
+++ b/Glob.cabal
@@ -47,6 +47,8 @@ Library
                     System.FilePath.Glob.Simplify
                     System.FilePath.Glob.Utils
 
+   GHC-Options: -Wall
+
 Test-Suite glob-tests
    type: exitcode-stdio-1.0
 

--- a/System/FilePath/Glob/Base.hs
+++ b/System/FilePath/Glob/Base.hs
@@ -30,7 +30,10 @@ import Data.Char                         (isDigit, isAlpha, toLower)
 import Data.List                         (find, sortBy)
 import Data.List.NonEmpty                (toList)
 import Data.Maybe                        (fromMaybe)
+-- Monoid is re-exported from Prelude as of 4.8.0.0
+#if !MIN_VERSION_base(4,8,0)
 import Data.Monoid                       (Monoid, mappend, mempty, mconcat)
+#endif
 import Data.Semigroup                    (Semigroup, (<>), sconcat, stimes)
 import Data.String                       (IsString(fromString))
 import System.FilePath                   ( pathSeparator, extSeparator

--- a/System/FilePath/Glob/Match.hs
+++ b/System/FilePath/Glob/Match.hs
@@ -1,10 +1,14 @@
 -- File created: 2008-10-10 13:29:03
 
+{-# LANGUAGE CPP #-}
+
 module System.FilePath.Glob.Match (match, matchWith) where
 
 import Control.Exception (assert)
 import Data.Char         (isDigit, toLower, toUpper)
+#if !MIN_VERSION_base(4,8,0)
 import Data.Monoid       (mappend)
+#endif
 import System.FilePath   (isPathSeparator, isExtSeparator)
 
 import System.FilePath.Glob.Base  ( Pattern(..), Token(..)


### PR DESCRIPTION
Enables warnings in Glob.cabal with -Wall, and additionally adds -Werror to Travis CI builds. See discussion in #17.