### PR TITLE
Add Unmatchable token, fixes #23

### DIFF
--- a/System/FilePath/Glob/Match.hs
+++ b/System/FilePath/Glob/Match.hs
@@ -125,6 +125,8 @@ match' o (LongLiteral len s:xs) path =
    let (pre,cs) = splitAt len path
     in pre == s && match' o xs cs
 
+match' _ (Unmatchable:_) _ = False
+
 -- Does the actual open range matching: finds whether the third parameter
 -- is between the first two or not.
 --

--- a/tests/Tests/Instances.hs
+++ b/tests/Tests/Instances.hs
@@ -42,8 +42,7 @@ prop_monoidLaw3 opt x =
     in isRight e && mappend a mempty == a
 
 -- mappending two Patterns should be equivalent to appending the original
--- strings they came from and compiling that, as long as the second doesn't
--- start with [.]
+-- strings they came from and compiling that
 --
 -- (notice: relies on the fact that our Arbitrary instance doesn't generate
 -- unclosed [] or <>; we only check for **/)

--- a/tests/Tests/Instances.hs
+++ b/tests/Tests/Instances.hs
@@ -42,7 +42,8 @@ prop_monoidLaw3 opt x =
     in isRight e && mappend a mempty == a
 
 -- mappending two Patterns should be equivalent to appending the original
--- strings they came from and compiling that
+-- strings they came from and compiling that, as long as the second doesn't
+-- start with [.]
 --
 -- (notice: relies on the fact that our Arbitrary instance doesn't generate
 -- unclosed [] or <>; we only check for **/)
@@ -56,4 +57,5 @@ prop_monoid4 opt x y =
        head2 = take 2 . unPS $ y
     in     (last2 /= "**" && take 1 head2 /= "/")
         && (take 1 last2 /= "*" && take 2 head2 /= "*/")
+        && (take 3 (unPS y) /= "[.]")
        ==> all isRight es && isRight cat2 && cat1 == fromRight cat2

--- a/tests/Tests/Regression.hs
+++ b/tests/Tests/Regression.hs
@@ -31,8 +31,8 @@ nameMatchTest (False,p,s) = show p ++ " doesn't match " ++ show s
 decompileCases =
    [ ("range-compression-1", "[*]",   "[*]")
    , ("range-compression-2", "[.]",   "[.]")
-   , ("range-compression-3", "**[/]", "*[/]")
-   , ("range-compression-4", "x[.]",  "x[.]")
+   , ("range-compression-3", "**[/]", "[.]")
+   , ("range-compression-4", "x[.]",  "x.")
    , ("range-compression-5", "[^~-]", "[^~-]")
    , ("range-compression-6", "[^!-]", "[^!-]")
    ]


### PR DESCRIPTION
Optimize unmatchable patterns to just [Unmatchable], i.e.
`compile "[.]"`.

Also strengthen tests for commonDirectory edge cases to ensure that
tests fail a little more reliably if this issue is present.