### PR TITLE
Fix ** implicitly matching dot directories when set to False

### DIFF
--- a/System/FilePath/Glob/Match.hs
+++ b/System/FilePath/Glob/Match.hs
@@ -127,7 +127,7 @@ match' o again@(AnyNonPathSeparator:xs) path@(c:cs) =
 match' o (AnyDirectory:xs) path =
    if matchDotsImplicitly o
       then hasMatch
-      -- **/baz shouldn't match foo/.bar/baz, so check that none of the
+      --  **/baz shouldn't match foo/.bar/baz, so check that none of the
       -- directories matched by **/ start with .
       else all (not.isExtSeparator.head) matchedDirs && hasMatch
  where parts   = pathParts (dropWhile isPathSeparator path)

--- a/System/FilePath/Glob/Match.hs
+++ b/System/FilePath/Glob/Match.hs
@@ -129,7 +129,7 @@ match' o (AnyDirectory:xs) path =
       then hasMatch
       --  **/baz shouldn't match foo/.bar/baz, so check that none of the
       -- directories matched by **/ start with .
-      else all (not.isExtSeparator.head) matchedDirs && hasMatch
+      else hasMatch && all (not.isExtSeparator.head) matchedDirs
  where parts   = pathParts (dropWhile isPathSeparator path)
        matchIndex = findIndex (match' o xs) parts
        hasMatch = isJust matchIndex

--- a/System/FilePath/Glob/Match.hs
+++ b/System/FilePath/Glob/Match.hs
@@ -74,6 +74,7 @@ begMatch opts pat s = match' opts pat s
 match' _ []                        s  = null s
 match' _ (AnyNonPathSeparator:s)   "" = null s
 match' _ _                         "" = False
+
 match' o (Literal l       :xs) (c:cs) = l == c && match' o xs cs
 match' o (NonPathSeparator:xs) (c:cs) =
    not (isPathSeparator c) && match' o xs cs
@@ -125,7 +126,7 @@ match' o again@(AnyNonPathSeparator:xs) path@(c:cs) =
 match' o again@(AnyDirectory:xs) path =
    let parts   = pathParts (dropWhile isPathSeparator path)
        matches = any (match' o xs) parts || any (match' o again) (tail parts)
-    in if null xs && not (matchDotsImplicitly o)
+    in if not (matchDotsImplicitly o)
           --  **/ shouldn't match foo/.bar, so check that remaining bits don't
           -- start with .
           then all (not.isExtSeparator.head) (init parts) && matches

--- a/tests/Tests/Regression.hs
+++ b/tests/Tests/Regression.hs
@@ -141,8 +141,12 @@ matchCases =
    , (False, "<-><->"     , "1")
    , (True,  "<0-0><1-1>" , "01")
    , (True,  "<0-1><0-1>" , "00")
-   , (False, "foo/**/asdf", "foo/.bar/baz/asdf")
-   , (False, "foo/**/asdf", "foo/bar/.baz/asdf")
+   , (False, "a/**/d"     , "a/.b/c/d")
+   , (False, "a/**/d"     , "a/b/.c/d")
+   , (True,  "a/**/.d"    , "a/b/c/.d")
+   , (True,  "a/**/.c/d"  , "a/b/.c/d")
+   , (True,  "a/**/.c/.d" , "a/b/.c/.d")
+   , (True,  "a/**/.d/.e" , "a/b/c/.d/.e")
    ]
 
 matchWithCases :: [(Bool, CompOptions, MatchOptions, String, String)]

--- a/tests/Tests/Regression.hs
+++ b/tests/Tests/Regression.hs
@@ -141,6 +141,8 @@ matchCases =
    , (False, "<-><->"     , "1")
    , (True,  "<0-0><1-1>" , "01")
    , (True,  "<0-1><0-1>" , "00")
+   , (False, "foo/**/asdf", "foo/.bar/baz/asdf")
+   , (False, "foo/**/asdf", "foo/bar/.baz/asdf")
    ]
 
 matchWithCases :: [(Bool, CompOptions, MatchOptions, String, String)]


### PR DESCRIPTION
fixes #29 

There was a check for `null xs` that was preventing it from checking directories past the first one.