### PR TITLE
Allow semigroups-0.19

### DIFF
--- a/Glob.cabal
+++ b/Glob.cabal
@@ -34,7 +34,7 @@ Library
                 , transformers-compat >= 0.3 && < 0.7
 
    if impl(ghc < 8.0)
-      Build-Depends: semigroups >= 0.18 && < 0.19
+      Build-Depends: semigroups >= 0.18 && < 0.20
 
    if os(windows)
       Build-Depends: Win32 == 2.*


### PR DESCRIPTION
I noted from the changelog, that you make "too big" version increments.

Packages on Hackage should follow [PVP versioning policy](https://pvp.haskell.org/), thus for example changes like

> 0.9.2, 2018-02-26:
>	Updated dependencies to allow transformers-compat-0.6.

Could actually been from `0.9.1` to `0.9.1.1`. Also test-only updates are not visible in public API, so could be included in patch release. note: *4th digit*, super.major.minor.patch)

Even better is to use [revisions](https://github.com/haskell-infra/hackage-trustees/blob/master/revisions-information.md) to make metadata (e.g. `build-depends`) corrections. E.g. if you click on version number in https://hackage.haskell.org/package/Glob/maintain you'll get to the revision making web ui. (*edit package information* link on package page).

Making "bigger" versions increments is not wrong, but discouraged. People and tooling use semantics for greater good (e.g. if there's a minor release, I read the changelog to see "what's new")

Thanks in advance!