### PR TITLE
remove upper bounds of dependencies

### DIFF
--- a/Glob.cabal
+++ b/Glob.cabal
@@ -26,19 +26,19 @@ Source-Repository head
   Location: https://github.com/Deewiant/glob
 
 Library
-   Build-Depends: base         >= 4 && < 5
-                , containers   <  0.7
-                , directory    <  1.4
-                , dlist        >= 0.4 && < 1.1
-                , filepath     >= 1.1 && < 1.5
-                , transformers >= 0.2 && < 0.6
-                , transformers-compat >= 0.3 && < 0.8
+   Build-Depends: base                >= 4 && < 5
+                , containers
+                , directory
+                , dlist               >= 0.4
+                , filepath            >= 1.1
+                , transformers        >= 0.2
+                , transformers-compat >= 0.3
 
    if impl(ghc < 8.0)
-      Build-Depends: semigroups >= 0.18 && < 0.21
+      Build-Depends: semigroups >= 0.18
 
    if os(windows)
-      Build-Depends: Win32 == 2.*
+      Build-Depends: Win32 >= 2
 
    Default-Language: Haskell98
 
@@ -59,23 +59,23 @@ Test-Suite glob-tests
    main-is: Main.hs
 
    Build-Depends: base                       >= 4 && < 5
-                , containers                 <  0.7
-                , directory                  <  1.4
-                , dlist                      >= 0.4 && < 1.1
-                , filepath                   >= 1.1 && < 1.5
-                , transformers               >= 0.2 && < 0.6
-                , transformers-compat        >= 0.3 && < 0.8
-                , HUnit                      >= 1.2 && < 1.7
-                , QuickCheck                 >= 2 && < 3
-                , test-framework             >= 0.2 && < 1
-                , test-framework-hunit       >= 0.2 && < 1
-                , test-framework-quickcheck2 >= 0.3 && < 1
+                , containers
+                , directory
+                , dlist                      >= 0.4
+                , filepath                   >= 1.1
+                , transformers               >= 0.2
+                , transformers-compat        >= 0.3
+                , HUnit                      >= 1.2
+                , QuickCheck                 >= 2
+                , test-framework             >= 0.2
+                , test-framework-hunit       >= 0.2
+                , test-framework-quickcheck2 >= 0.3
 
    if impl(ghc < 8.0)
-      Build-Depends: semigroups >= 0.18 && < 0.20
+      Build-Depends: semigroups >= 0.18
 
    if os(windows)
-      Build-Depends: Win32 == 2.*
+      Build-Depends: Win32 >= 2
 
    Default-Language: Haskell98
 


### PR DESCRIPTION
I think that upper bounds of dependencies that are not released yet are not necessary. When some versions will get incompatible, then upper bounds may be added.

Current versions of packages that are removed by this PR:

- containers-0.6.5.1
- directory-1.2.7.0
- dlist-1.0
- filepath-1.4.2.1
- transformers-0.6.0.2
- transformers-compat-0.7.1
- semigroups-0.20
- HUnit-1.6.2.0
- test-framework-0.8.2.0
- test-framework-hunit-0.3.0.2
- test-framework-quickcheck2-0.3.0.5